### PR TITLE
Fix sql paths on creation and deletion

### DIFF
--- a/Config/sqldb.map
+++ b/Config/sqldb.map
@@ -1,2 +1,0 @@
-# Sqlfile -> Database map
-thelia.sql=thelia

--- a/ProductsPack.php
+++ b/ProductsPack.php
@@ -23,7 +23,7 @@ class ProductsPack extends BaseModule
         parent::postActivation($con);
         if (!is_null($con)) {
             $database = new Database($con);
-            $database->insertSql(null, array(THELIA_ROOT . '/local/modules/ProductsPack/Config/create.sql'));
+            $database->insertSql(null, array(__DIR__ . '/Config/create.sql'));
         }
     }
     
@@ -32,7 +32,7 @@ class ProductsPack extends BaseModule
         parent::destroy($con, $deleteModuleData);
         if(!is_null($con) && $deleteModuleData === true) {
             $database = new Database($con);
-            $database->insertSql(null, array(THELIA_ROOT . '/local/modules/ProductsPack/Config/delete.sql'));
+            $database->insertSql(null, array(__DIR__ . '/Config/delete.sql'));
         }
     }
 }


### PR DESCRIPTION
Hello, here's a fix for sql execution on action / deactivation. I had the problem of file not found because my `THELIA_ROOT` my project tree isn't thelia's default.
Moreover, when propel's generation is done you can remove sqldb.map, as it isn't used anymore after.
